### PR TITLE
Network update and first method comments

### DIFF
--- a/cave/range.py
+++ b/cave/range.py
@@ -53,13 +53,13 @@ class Range():
         self.pool.create(self.libvirt_connection)
         return self.pool
          
-    def add_network(self, name: str, mode: str, ipv4_cidr: str, ingress_route_subnet: str="", ingress_route_gateway: str=""):
+    def add_network(self, name: str, mode: str, ipv4_cidr: str, ingress_route_subnet: str="", ingress_route_gateway: str="") -> Network:
 
         n = Network(name=name, 
                     host_isolated=True if mode == "" else False, 
                     ipv4_cidr=ipv4_cidr, 
                     isolate_guests=False,
-                    ipv6="", ipv6_prefix="", 
+                    ipv6_cidr="",  
                     mode=mode, 
                     ingress_route_subnet=ingress_route_subnet, ingress_route_gateway=ingress_route_gateway)
 
@@ -77,7 +77,7 @@ class Range():
                     host_isolated=False, 
                     ipv4_cidr=ipv4_cidr, 
                     isolate_guests=False,
-                    ipv6="", ipv6_prefix="", 
+                    ipv6_cidr="", 
                     mode="open", 
                     ingress_route_subnet="", ingress_route_gateway="")
 
@@ -287,7 +287,7 @@ class Range():
         for domain in self.domains:
             logger.info(f"removing management network interface for domain {domain.name}")
             domain.remove_interface_for_network_name(self.management_network.name)
-        self.management_network.destroy()
+        self.management_network.remove()
         self.networks.remove(self.management_network)
         logger.info(f"done removing management network {self.management_network.name}")
 

--- a/cave/range.py
+++ b/cave/range.py
@@ -53,11 +53,11 @@ class Range():
         self.pool.create(self.libvirt_connection)
         return self.pool
          
-    def add_network(self, name: str, mode: str, ipv4: str, ipv4_subnet: str, ingress_route_subnet=None, ingress_route_gateway=None):
+    def add_network(self, name: str, mode: str, ipv4_cidr: str, ingress_route_subnet: str="", ingress_route_gateway: str=""):
 
         n = Network(name=name, 
                     host_isolated=True if mode == "" else False, 
-                    ipv4=ipv4, ipv4_subnet=ipv4_subnet, 
+                    ipv4_cidr=ipv4_cidr, 
                     isolate_guests=False,
                     ipv6="", ipv6_prefix="", 
                     mode=mode, 
@@ -68,18 +68,18 @@ class Range():
         self.networks.append(n)
         return n
 
-    def add_management_network(self, name: str, ipv4: str, ipv4_subnet: str):
+    def add_management_network(self, name: str, ipv4_cidr: str, ):
         if self.management_network:
             logger.error("Multiple management networks for a single range is not supported for now")
             return
 
         n = Network(name=name, 
                     host_isolated=False, 
-                    ipv4=ipv4, ipv4_subnet=ipv4_subnet, 
+                    ipv4_cidr=ipv4_cidr, 
                     isolate_guests=False,
                     ipv6="", ipv6_prefix="", 
                     mode="open", 
-                    ingress_route_subnet=None, ingress_route_gateway=None)
+                    ingress_route_subnet="", ingress_route_gateway="")
 
         n.create(self.libvirt_connection)
         self.networks.append(n)
@@ -287,7 +287,7 @@ class Range():
         for domain in self.domains:
             logger.info(f"removing management network interface for domain {domain.name}")
             domain.remove_interface_for_network_name(self.management_network.name)
-        self.management_network.rm()
+        self.management_network.destroy()
         self.networks.remove(self.management_network)
         logger.info(f"done removing management network {self.management_network.name}")
 

--- a/cave/src/domains/interface.py
+++ b/cave/src/domains/interface.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass
 class Interface:
     mac: str
     network: Network
-    ipv4: str
-    prefix_length: int
+    ipv4_cidr: str
     is_mngmt: bool
 

--- a/test/test.py
+++ b/test/test.py
@@ -49,12 +49,10 @@ range.add_pool("pool1",REMOTE_POOL_DIR)
 
 # isolated network
 mngt = range.add_management_network(name="mngmt", 
-                         ipv4="10.10.0.1", 
-                         ipv4_subnet="255.255.255.0")
+                         ipv4_cidr="10.10.0.1/24")
 
 n1 = range.add_network(name="network1", 
-                       ipv4="", 
-                       ipv4_subnet="", 
+                       ipv4_cidr="",
                        mode="")
 
 i1 = Interface(mac="", 

--- a/test/test.py
+++ b/test/test.py
@@ -57,14 +57,12 @@ n1 = range.add_network(name="network1",
 
 i1 = Interface(mac="", 
                network=n1, 
-               ipv4="10.10.1.2", 
-               prefix_length=24, 
+               ipv4_cidr="10.10.1.2/24", 
                is_mngmt=False) 
 
 im = Interface(mac="", 
                network=mngt, 
-               ipv4="10.10.0.2", 
-               prefix_length=24, 
+               ipv4_cidr="10.10.0.2/24", 
                is_mngmt=True) 
 
 ubuntu_img = f"{REMOTE_IMAGES_DIR}/{os.path.basename(UBUNTU_IMAGE)}"
@@ -85,28 +83,24 @@ ld = range.add_linux_domain(name="linux01",
 
 i1 = Interface(mac="", 
                network=n1, 
-               ipv4="10.10.1.4", 
-               prefix_length=24, 
+               ipv4_cidr="10.10.1.4/24", 
                is_mngmt=False) 
 
 im = Interface(mac="", 
                network=mngt, 
-               ipv4="10.10.0.4", 
-               prefix_length=24, 
+               ipv4_cidr="10.10.0.4/24", 
                is_mngmt=True) 
 
 ld = range.add_linux_domain("linux02", "lin02", ubuntu_img, [i1, im], "pw", 8, 1024, 2, "6001", "no", "0.0.0.0", "10.10.1.1", "1.1.1.1", "10.10.0.1") 
 
 i1 = Interface(mac="", 
                network=n1, 
-               ipv4="10.10.1.3", 
-               prefix_length=24, 
+               ipv4_cidr="10.10.1.3/24", 
                is_mngmt=False) 
 
 im = Interface(mac="", 
                network=mngt, 
-               ipv4="10.10.0.3",
-               prefix_length=24, 
+               ipv4_cidr="10.10.0.3",
                is_mngmt=True) 
 
 windows_server22_iso = f"{REMOTE_IMAGES_DIR}/{os.path.basename(WINDOWS_SERVER_ISO)}"


### PR DESCRIPTION
Changed network definition with more fitting defaults 
Combined ipv4_subnet and ipv4 into ipv4_cidr to be more consistent with other uses of ipv4
updated test.py and range.py for new network setup 
renamed network.rm() to be consistent with network.destroy_by_name()